### PR TITLE
v1.1.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.jvmargs=-Xmx4G
 loom.platform=neoforge
 
-mod_version=1.6-neoforge-1.1.1
+mod_version=1.6-neoforge-1.1.2
 maven_group=us.timinc.mc.cobblemon
 archives_base_name=whiteout
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.jvmargs=-Xmx4G
 loom.platform=neoforge
 
-mod_version=1.6-neoforge-1.1.0
+mod_version=1.6-neoforge-1.1.1
 maven_group=us.timinc.mc.cobblemon
 archives_base_name=whiteout
 

--- a/src/main/kotlin/us/timinc/mc/cobblemon/whiteout/Whiteout.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/whiteout/Whiteout.kt
@@ -11,10 +11,7 @@ import net.minecraft.core.registries.Registries
 import net.minecraft.resources.ResourceKey
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.world.damagesource.DamageType
-import net.neoforged.bus.api.SubscribeEvent
-import net.neoforged.fml.common.EventBusSubscriber
 import net.neoforged.fml.common.Mod
-import net.neoforged.neoforge.event.server.ServerStartedEvent
 import us.timinc.mc.cobblemon.whiteout.config.ConfigBuilder
 import us.timinc.mc.cobblemon.whiteout.config.WhiteoutConfig
 

--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -4,7 +4,7 @@ license = "MIT"
 
 [[mods]]
 modId = "whiteout"
-version = "1.6-neoforge-1.1.1"
+version = "1.6-neoforge-1.1.2"
 displayName = "Cobblemon Whiteout"
 authors = "timinc aka Timothy Metcalfe"
 description = '''

--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -4,7 +4,7 @@ license = "MIT"
 
 [[mods]]
 modId = "whiteout"
-version = "1.6-neoforge-1.1.0"
+version = "1.6-neoforge-1.1.1"
 displayName = "Cobblemon Whiteout"
 authors = "timinc aka Timothy Metcalfe"
 description = '''


### PR DESCRIPTION
* Moved event handler registration from annotations to init. Change precipitated by an oddity in newer versions of KFF/NF that caused annotation-based event registration to fail (looks like NF removed access to something? idk). This should work across versions.