### PR TITLE
v1.2.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.jvmargs=-Xmx4G
 loom.platform=neoforge
 
-mod_version=1.6-neoforge-1.2.1
+mod_version=1.6-neoforge-1.2.2
 maven_group=us.timinc.mc.cobblemon
 archives_base_name=whiteout
 

--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -4,7 +4,7 @@ license = "MIT"
 
 [[mods]]
 modId = "whiteout"
-version = "1.6-neoforge-1.2.1"
+version = "1.6-neoforge-1.2.2"
 displayName = "Cobblemon Whiteout"
 authors = "timinc aka Timothy Metcalfe"
 description = '''

--- a/src/main/resources/data/minecraft/tags/damage_type/bypasses_armor.json
+++ b/src/main/resources/data/minecraft/tags/damage_type/bypasses_armor.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "whiteout:fled",
+    "whiteout:pokebattle"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/damage_type/bypasses_effects.json
+++ b/src/main/resources/data/minecraft/tags/damage_type/bypasses_effects.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "whiteout:fled",
+    "whiteout:pokebattle"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/damage_type/damage_is_absolute.json
+++ b/src/main/resources/data/minecraft/tags/damage_type/damage_is_absolute.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "whiteout:fled",
+    "whiteout:pokebattle"
+  ]
+}


### PR DESCRIPTION
* Custom damage types now bypass armor (so they don't break it), as well as effects, and the damage is a flat number.